### PR TITLE
Fix #1 by cleaning file path on Windows

### DIFF
--- a/jupyterhere/__init__.py
+++ b/jupyterhere/__init__.py
@@ -1,7 +1,15 @@
 from fman import DirectoryPaneCommand
 import subprocess
+import os
+
 
 class JupyterHere(DirectoryPaneCommand):
     def __call__(self):
-        subprocess.call(r'jupyter-notebook ' + 
-        				r'--notebook-dir="{cd}"'.format(cd=self.pane.get_path()))
+        cd = self.pane.get_path()
+
+        # Clean path if running on Windows
+        if os.path == 'nt':
+            cd = cd.lstrip('file:/').rstrip('\\')
+
+        subprocess.call(r'jupyter-notebook ' +
+        				r'--notebook-dir="{}"'.format(cd))


### PR DESCRIPTION
self.pane.get_path() returns a path starting with file:// which is OK for POSIX based operating systems but needs to be removed for Windows.